### PR TITLE
ci: smoke test against live ODS API on main + weekly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    # Weekly live smoke test against data.regionreunion.com (Mon 06:00 UTC).
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
 
 jobs:
   build-and-test:
@@ -29,3 +33,28 @@ jobs:
 
       - name: Test
         run: npm test
+
+  smoke:
+    # Hits the live ODS API → skip on PR runs so external outages don't
+    # block merges. Runs on main pushes, the weekly schedule, and manual
+    # dispatch to catch real API regressions.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Smoke test
+        run: npm run test:smoke


### PR DESCRIPTION
## Summary
- Extends the existing CI workflow with a second \`smoke\` job
- Runs \`npm run test:smoke\` (hits \`data.regionreunion.com\` for all 88 tools) on push to \`main\`, weekly cron (Mon 06:00 UTC) and manual dispatch
- Skips on PR runs so external outages never block a merge; the existing \`build-and-test\` job still gates PRs

## Test plan
- [ ] \`build-and-test\` green on this PR (smoke correctly skipped)
- [ ] \`smoke\` job runs on main after merge