### PR TITLE
test: unit coverage for helpers + cache + tool ODSQL

### DIFF
--- a/tests/client-cache.test.ts
+++ b/tests/client-cache.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ReunionClient } from '../src/client.js';
+
+describe('ReunionClient in-memory cache', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let client: ReunionClient;
+
+  beforeEach(() => {
+    client = new ReunionClient();
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify({ total_count: 42, results: [{ ok: true }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('caches referential datasets across repeat calls with the same params', async () => {
+    const params = { where: 'year = 2022', limit: 10 };
+    await client.getRecords('communes-millesime-france', params);
+    await client.getRecords('communes-millesime-france', params);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT cross-cache between different params on the same referential dataset', async () => {
+    await client.getRecords('communes-millesime-france', { limit: 10 });
+    await client.getRecords('communes-millesime-france', { limit: 20 });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT cache non-referential datasets (SIRENE, DVF, etc.)', async () => {
+    await client.getRecords('base-sirene-v3-lareunion', { limit: 1 });
+    await client.getRecords('base-sirene-v3-lareunion', { limit: 1 });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('clearCaches() forces the next referential call to hit the network again', async () => {
+    await client.getRecords('iris-millesime-france', { limit: 5 });
+    await client.getRecords('iris-millesime-france', { limit: 5 });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    client.clearCaches();
+    await client.getRecords('iris-millesime-france', { limit: 5 });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildWhere,
+  escapeOdSqlString,
+  quote,
+  normalizeText,
+  pickString,
+  pickNumber,
+  pickBoolean,
+  pickValue,
+} from '../src/utils/helpers.js';
+
+describe('quote / escapeOdSqlString', () => {
+  it('wraps value in single quotes', () => {
+    expect(quote('hello')).toBe("'hello'");
+  });
+
+  it("doubles embedded single quotes to prevent ODSQL injection", () => {
+    expect(quote("L'Hermitage")).toBe("'L''Hermitage'");
+    expect(escapeOdSqlString("it's 'mine'")).toBe("it''s ''mine''");
+  });
+});
+
+describe('buildWhere', () => {
+  it('joins truthy conditions with AND', () => {
+    expect(buildWhere(['a = 1', 'b = 2', 'c = 3'])).toBe('a = 1 AND b = 2 AND c = 3');
+  });
+
+  it('filters out undefined/null/false entries (the conditional-filter pattern used everywhere)', () => {
+    expect(buildWhere(['a = 1', undefined, false, null, 'b = 2'])).toBe('a = 1 AND b = 2');
+  });
+
+  it('returns undefined when no conditions are truthy', () => {
+    expect(buildWhere([undefined, null, false])).toBeUndefined();
+    expect(buildWhere([])).toBeUndefined();
+  });
+});
+
+describe('normalizeText', () => {
+  it('strips accents and lowercases', () => {
+    expect(normalizeText('Réunion')).toBe('reunion');
+    expect(normalizeText('  CAFÉ  ')).toBe('cafe');
+  });
+});
+
+describe('pickValue / pickString / pickNumber / pickBoolean', () => {
+  const row = {
+    name: 'Saint-Denis',
+    population: 149337,
+    pct: '12.5',
+    active: 1,
+    empty_str: '',
+    null_val: null,
+  } as Record<string, unknown>;
+
+  it('pickValue returns first defined candidate', () => {
+    expect(pickValue(row, ['missing', 'name'])).toBe('Saint-Denis');
+    expect(pickValue(row, ['null_val', 'name'])).toBe('Saint-Denis'); // null skipped
+    expect(pickValue(row, ['missing'])).toBeUndefined();
+  });
+
+  it('pickString coerces numbers to strings', () => {
+    expect(pickString(row, ['population'])).toBe('149337');
+    expect(pickString(row, ['name'])).toBe('Saint-Denis');
+    expect(pickString(row, ['missing'])).toBeUndefined();
+  });
+
+  it('pickNumber parses numeric strings and rejects non-finite', () => {
+    expect(pickNumber(row, ['population'])).toBe(149337);
+    expect(pickNumber(row, ['pct'])).toBe(12.5);
+    expect(pickNumber(row, ['name'])).toBeUndefined(); // non-numeric string
+    expect(pickNumber(row, ['empty_str'])).toBeUndefined();
+  });
+
+  it('pickBoolean understands French / numeric truth values', () => {
+    expect(pickBoolean(row, ['active'])).toBe(true);
+    expect(pickBoolean({ v: 'Oui' }, ['v'])).toBe(true);
+    expect(pickBoolean({ v: 'non' }, ['v'])).toBe(false);
+    expect(pickBoolean({ v: 0 }, ['v'])).toBe(false);
+    expect(pickBoolean({ v: 'maybe' }, ['v'])).toBeUndefined();
+  });
+});

--- a/tests/tools-odsql.test.ts
+++ b/tests/tools-odsql.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { client } from '../src/client.js';
+import { registerTransportTools } from '../src/modules/transport.js';
+import { registerTerritoryTools } from '../src/modules/territory.js';
+import { registerAdministrationTools } from '../src/modules/administration.js';
+
+// Minimal stand-in for McpServer that just captures tool registrations so
+// each handler can be invoked directly with crafted args and its ODSQL
+// query inspected via a spy on `client.getRecords`.
+interface CapturedTool {
+  schema: unknown;
+  handler: (args: Record<string, unknown>) => Promise<unknown>;
+}
+
+class FakeMcpServer {
+  tools = new Map<string, CapturedTool>();
+  tool(name: string, _desc: string, schema: unknown, handler: CapturedTool['handler']): void {
+    this.tools.set(name, { schema, handler });
+  }
+}
+
+function invoke(server: FakeMcpServer, toolName: string, args: Record<string, unknown>) {
+  const tool = server.tools.get(toolName);
+  if (!tool) throw new Error(`Tool not registered: ${toolName}`);
+  return tool.handler(args);
+}
+
+describe('tool → ODSQL snapshot', () => {
+  let server: FakeMcpServer;
+  let spy: ReturnType<typeof vi.spyOn<typeof client, 'getRecords'>>;
+
+  beforeEach(() => {
+    server = new FakeMcpServer();
+    registerTransportTools(server as unknown as McpServer);
+    registerTerritoryTools(server as unknown as McpServer);
+    registerAdministrationTools(server as unknown as McpServer);
+    spy = vi.spyOn(client, 'getRecords').mockResolvedValue({
+      total_count: 0,
+      results: [],
+    } as never);
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  describe('transport.reunion_search_road_accidents', () => {
+    it('filters commune via com_name (regression guard for nom_com/com_name swap)', async () => {
+      await invoke(server, 'reunion_search_road_accidents', {
+        commune: 'Saint-Denis',
+        limit: 5,
+      });
+      const [, params] = spy.mock.calls[0];
+      expect(params?.where).toContain("com_name LIKE 'Saint-Denis%'");
+      expect(params?.where ?? '').not.toContain('nom_com');
+    });
+
+    it('filters year and severity', async () => {
+      await invoke(server, 'reunion_search_road_accidents', {
+        year: 2019,
+        severity: 2,
+        limit: 5,
+      });
+      const [, params] = spy.mock.calls[0];
+      expect(params?.where).toContain('an = 2019');
+      expect(params?.where).toContain('grav = 2');
+    });
+  });
+
+  describe('territory.reunion_search_real_estate_transactions', () => {
+    it('converts year to a datemut date range (anneemut is stored as a date, not int)', async () => {
+      await invoke(server, 'reunion_search_real_estate_transactions', {
+        year: 2022,
+        limit: 5,
+      });
+      const [, params] = spy.mock.calls[0];
+      expect(params?.where).toContain("datemut >= date'2022-01-01'");
+      expect(params?.where).toContain("datemut < date'2023-01-01'");
+      expect(params?.where ?? '').not.toMatch(/\banneemut\s*=\s*\d+\b/);
+    });
+
+    it('stacks min/max value filters with AND', async () => {
+      await invoke(server, 'reunion_search_real_estate_transactions', {
+        min_value: 100000,
+        max_value: 500000,
+        limit: 1,
+      });
+      const [, params] = spy.mock.calls[0];
+      expect(params?.where).toContain('valeurfonc >= 100000');
+      expect(params?.where).toContain('valeurfonc <= 500000');
+      expect(params?.where).toMatch(/AND/);
+    });
+  });
+
+  describe('administration.reunion_search_baby_names', () => {
+    it('uppercases the name prefix and quotes the year as a string', async () => {
+      await invoke(server, 'reunion_search_baby_names', {
+        name: 'lea',
+        year: 2020,
+        sex: '2',
+        limit: 5,
+      });
+      const [, params] = spy.mock.calls[0];
+      expect(params?.where).toContain("preusuel LIKE 'LEA%'");
+      expect(params?.where).toContain("annais = '2020'");
+      expect(params?.where).toContain("sexe = '2'");
+    });
+  });
+
+  describe('escaping', () => {
+    it("doubles embedded single quotes so commune names like L'Étang-Salé don't break ODSQL", async () => {
+      await invoke(server, 'reunion_search_road_accidents', {
+        commune: "L'Étang-Salé",
+        limit: 1,
+      });
+      const [, params] = spy.mock.calls[0];
+      expect(params?.where).toContain("L''Étang-Salé");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds 20 new unit tests across 3 files, plugging the gap that let the \`nom_com\` / \`anneemut\`-as-date bugs slip through:

- **\`tests/helpers.test.ts\`** (10) — \`buildWhere\` / \`quote\` / \`escapeOdSqlString\` / \`normalizeText\` / \`pickString\` / \`pickNumber\` / \`pickBoolean\`. Covers the ODSQL-injection guard (\`L'Hermitage\` → \`L''Hermitage\`) and the "filter undefined out of conditions" pattern used across every tool.
- **\`tests/client-cache.test.ts\`** (4) — mocks \`fetch\` to verify the 24h cache hits on referential datasets (communes, IRIS…), stays miss on non-referential (SIRENE, DVF), and invalidates on different params / \`clearCaches()\`.
- **\`tests/tools-odsql.test.ts\`** (6) — \`FakeMcpServer\` captures tool registrations and a spy on \`client.getRecords\` asserts the exact ODSQL emitted. Includes explicit regression guards:
  - \`search_road_accidents\` must use \`com_name\` (not \`nom_com\`) for the commune filter
  - \`search_real_estate_transactions\` must convert \`year\` to a \`datemut\` date range (not \`anneemut = N\`)
  - \`search_baby_names\` must uppercase the prefix and quote the year as a string

The existing \`tests/client.test.ts\` (live integration) keeps running alongside.

## Test plan
- [x] \`npm test\` → 24 passed (20 new + 4 existing)
- [x] \`npm run build\` clean