### PR TITLE
feat(commune): reunion_find_commune fuzzy resolver + unwrap ODS array fields

### DIFF
--- a/src/modules/commune.ts
+++ b/src/modules/commune.ts
@@ -4,7 +4,18 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { client } from '../client.js';
 import { RecordObject } from '../types.js';
-import { errorResult, jsonResult, pickNumber, pickString, quote } from '../utils/helpers.js';
+import { errorResult, jsonResult, normalizeText, pickNumber, pickString, quote } from '../utils/helpers.js';
+
+// ODS's search() and LIKE both reject embedded single quotes ("L'Étang-Salé"
+// breaks the ODSQL parser even when properly escaped). Strip them and expand
+// French place-name abbreviations before sending to the upstream.
+function normalizeCommuneQuery(query: string): string {
+  return query
+    .replace(/[''’]/g, ' ')
+    .replace(/\bSt(e?)\b\.?/gi, (_m, e) => `Saint${e ?? ''}`)
+    .replace(/\s+/g, ' ')
+    .trim();
+}
 
 // Each dimension of the profile is fetched in parallel from its source dataset,
 // and failures on individual dimensions are reported inline rather than failing
@@ -162,6 +173,75 @@ export function registerCommuneTools(server: McpServer): void {
       }
 
       return jsonResult(dimensions);
+    }
+  );
+
+  server.tool(
+    'reunion_find_commune',
+    'Resolve a fuzzy / approximate Réunion commune name or typo to its canonical INSEE code, EPCI, département. Use this to disambiguate user input before calling other tools.',
+    {
+      query: z.string().describe('Approximate commune name (case- and accent-insensitive)'),
+    },
+    async ({ query }) => {
+      try {
+        const cleaned = normalizeCommuneQuery(query);
+        let results: RecordObject[] = [];
+
+        if (cleaned) {
+          const odsSearch = await client.getRecords<RecordObject>('communes-millesime-france', {
+            where: `search(${quote(cleaned)})`,
+            order_by: 'year DESC',
+            limit: 25,
+          });
+          results = odsSearch.results;
+        }
+
+        // Fallback: pull every Réunion commune (24 rows, cached as a
+        // referential dataset) and match client-side on a normalized name.
+        // Collapse separators (apostrophes, hyphens, whitespace) so user
+        // input like "L Etang-Sale" still matches "L'Étang-Salé".
+        const collapse = (s: string) => normalizeText(s).replace(/[''’\-\s]+/g, '');
+        if (results.length === 0) {
+          const all = await client.getRecords<RecordObject>('communes-millesime-france', {
+            limit: 100,
+          });
+          const needle = collapse(cleaned);
+          if (needle) {
+            results = all.results.filter((row) => {
+              const haystack = collapse(pickString(row, ['com_name']) ?? '');
+              return haystack.includes(needle) || needle.includes(haystack);
+            });
+          }
+        }
+
+        // De-duplicate by INSEE code (the dataset has one row per millésime).
+        const byInsee = new Map<string, RecordObject>();
+        for (const row of results) {
+          const code = pickString(row, ['com_code']);
+          if (code && !byInsee.has(code)) byInsee.set(code, row);
+        }
+
+        return jsonResult({
+          query,
+          normalized_query: cleaned,
+          match_count: byInsee.size,
+          matches: Array.from(byInsee.values()).map((row) => ({
+            name: pickString(row, ['com_name']),
+            insee_code: pickString(row, ['com_code']),
+            current_insee_code: pickString(row, ['com_current_code']),
+            epci_name: pickString(row, ['epci_name']),
+            epci_code: pickString(row, ['epci_code']),
+            employment_zone: pickString(row, ['ze2020_name']),
+            living_basin: pickString(row, ['bv2022_name']),
+            department: pickString(row, ['dep_name']),
+            region: pickString(row, ['reg_name']),
+            mountain_area: pickNumber(row, ['com_is_mountain_area']),
+            year: pickString(row, ['year']),
+          })),
+        });
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : 'Failed to find commune');
+      }
     }
   );
 }

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -24,7 +24,7 @@ import { registerTransportTools } from './transport.js';
 import { registerUrbanismTools } from './urbanism.js';
 import { registerWeatherTools } from './weather.js';
 
-export const TOOL_COUNT = 89;
+export const TOOL_COUNT = 90;
 
 /**
  * Register all tool modules with the MCP server.

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -89,6 +89,12 @@ export function pickValue<T = unknown>(
     if (candidate in record) {
       const value = record[candidate];
       if (value !== undefined && value !== null) {
+        // OpenDataSoft v2.1 wraps some text fields as single-element arrays
+        // (e.g. com_name → ["Saint-Denis"]). Unwrap so downstream pickers
+        // see the scalar they expect.
+        if (Array.isArray(value) && value.length === 1) {
+          return value[0] as T;
+        }
         return value as T;
       }
     }

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -59,6 +59,14 @@ describe('pickValue / pickString / pickNumber / pickBoolean', () => {
     expect(pickValue(row, ['missing'])).toBeUndefined();
   });
 
+  it('pickValue unwraps single-element arrays (ODS v2.1 wraps some text fields like com_name → ["Saint-Denis"])', () => {
+    expect(pickValue({ com_name: ['Saint-Denis'] }, ['com_name'])).toBe('Saint-Denis');
+    expect(pickString({ com_code: ['97411'] }, ['com_code'])).toBe('97411');
+    expect(pickNumber({ population: [149337] }, ['population'])).toBe(149337);
+    // Multi-element arrays are kept as-is (still match downstream typeof check fails → undefined)
+    expect(pickString({ tags: ['a', 'b'] }, ['tags'])).toBeUndefined();
+  });
+
   it('pickString coerces numbers to strings', () => {
     expect(pickString(row, ['population'])).toBe('149337');
     expect(pickString(row, ['name'])).toBe('Saint-Denis');


### PR DESCRIPTION
## Summary
- New \`reunion_find_commune\` tool: resolves a fuzzy / approximate commune name (typos, \`St-\` ↔ \`Saint-\`, missing accents, embedded apostrophes) to its canonical INSEE code, EPCI, employment zone, etc. Useful as a disambiguation step before calling other tools.
- Two-tier matching: ODS \`search()\` first (with apostrophes stripped, since ODSQL chokes on them inside \`search()\` / \`LIKE\`), then a client-side normalized contains-match against the 24 communes (free thanks to the referential cache).

## Bug fix surfaced along the way
- \`pickValue\` now unwraps single-element arrays. OpenDataSoft v2.1 returns some text fields wrapped (\`com_name → ["Saint-Denis"]\`, \`com_code → ["97411"]\`), which silently broke field mapping in **every** module that reads INSEE millésimé layers (\`list_communes\`, \`list_iris\`, \`list_cantons\`, \`list_epci\`, …). The smoke test missed it because it only asserts \`total_count > 0\`.

## Test plan
- [x] \`npm test\` → 25 passed (24 existing + 1 new for the array-unwrap)
- [x] Manual: \"Saint-Denis\", \"St-Denis\", \"L'Etang-Sale\", \"L Etang Sale\", \"tampon\", \"Salazi\", \"Possession\", \"Le Port\" all resolve to the right commune