### PR TITLE
feat: presidential 2022, legislative R2, BOAMP, water management

### DIFF
--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -72,6 +72,12 @@ const TESTS = [
   { pr: 26, tool: 'list_priority_neighborhoods', dataset: 'quartiers-prioritaires-de-la-politique-de-la-ville-qpv', params: { limit: 1 } },
   { pr: 26, tool: 'search_baby_names', dataset: 'prenomsdpt974depuis2000', params: { order_by: 'nombre DESC', limit: 1 } },
   { pr: 26, tool: 'search_baby_names (filtered)', dataset: 'prenomsdpt974depuis2000', params: { where: "preusuel LIKE 'LEA%' AND annais = '2020'", limit: 1 } },
+
+  // --- Long-tail (administration + environment extensions)
+  { pr: 35, tool: 'get_legislative_2022_round2', dataset: 'resultats-des-elections-legislatives-2022-2nd-tour-par-bureau-de-vote-a-la-reuni', params: { order_by: 'voix DESC', limit: 1 } },
+  { pr: 35, tool: 'get_presidential_2022_round1', dataset: 'resultats-des-elections-presidentielles-2022-1er-tour-par-bureau-de-vote-a-la-re', params: { order_by: 'voix DESC', limit: 1 } },
+  { pr: 35, tool: 'search_boamp', dataset: 'boamp', params: { order_by: 'dateparution DESC', limit: 1 } },
+  { pr: 35, tool: 'list_water_management_points', dataset: 'les-points-d-activite-ou-d-interet-la-gestion-des-eaux', params: { limit: 1 } },
 ];
 
 function buildUrl(dataset, params) {

--- a/src/modules/administration.ts
+++ b/src/modules/administration.ts
@@ -11,8 +11,38 @@ const DATASET_ASSOCIATIONS = 'repertoire-local-des-associations-a-la-reunion';
 const DATASET_ELUS = 'liste-de-l-ensemble-des-elus-locaux';
 const DATASET_LEGIS_2022_T1 =
   'resultats-des-elections-legislatives-2022-1er-tour-par-bureau-de-vote-a-la-reuni';
+const DATASET_LEGIS_2022_T2 =
+  'resultats-des-elections-legislatives-2022-2nd-tour-par-bureau-de-vote-a-la-reuni';
+const DATASET_PRES_2022_T1 =
+  'resultats-des-elections-presidentielles-2022-1er-tour-par-bureau-de-vote-a-la-re';
 const DATASET_QPV = 'quartiers-prioritaires-de-la-politique-de-la-ville-qpv';
 const DATASET_NAMES = 'prenomsdpt974depuis2000';
+const DATASET_BOAMP = 'boamp';
+
+// Shared mapper for the per-polling-station election datasets — the 3 results
+// datasets (legis R1, legis R2, presidential R1) share the same schema.
+function mapBallotRow(row: RecordObject) {
+  return {
+    commune: pickString(row, ['com_name']),
+    commune_code: pickString(row, ['com_code']),
+    circumscription: pickString(row, ['libelle_de_la_circonscription']),
+    polling_station_code: pickString(row, ['code_du_b_vote']),
+    polling_station_name: pickString(row, ['lib_du_b_vote']),
+    registered: pickNumber(row, ['inscrits']),
+    abstentions: pickNumber(row, ['abstentions']),
+    voters: pickNumber(row, ['votants']),
+    blank: pickNumber(row, ['blancs']),
+    null_votes: pickNumber(row, ['nuls']),
+    expressed: pickNumber(row, ['exprimes']),
+    panel_num: pickNumber(row, ['ndegpanneau']),
+    candidate_last_name: pickString(row, ['nom']),
+    candidate_first_name: pickString(row, ['prenom']),
+    candidate_sex: pickString(row, ['sexe']),
+    political_label: pickString(row, ['nuance']),
+    votes: pickNumber(row, ['voix']),
+    votes_pct_expressed: pickNumber(row, ['voix_exp']),
+  };
+}
 
 export function registerAdministrationTools(server: McpServer): void {
   server.tool(
@@ -256,6 +286,112 @@ export function registerAdministrationTools(server: McpServer): void {
         });
       } catch (error) {
         return errorResult(error instanceof Error ? error.message : 'Failed to search baby names');
+      }
+    }
+  );
+
+  server.tool(
+    'reunion_get_legislative_2022_round2',
+    'Per-polling-station results of the 2022 legislative elections (2nd round) in La Réunion.',
+    {
+      commune: z.string().optional().describe('Commune filter (prefix match)'),
+      circumscription: z.string().optional().describe('Circonscription label filter (prefix match)'),
+      polling_station: z.string().optional().describe('Polling-station code filter (exact)'),
+      limit: z.number().int().min(1).max(500).default(100),
+    },
+    async ({ commune, circumscription, polling_station, limit }) => {
+      try {
+        const data = await client.getRecords<RecordObject>(DATASET_LEGIS_2022_T2, {
+          where: buildWhere([
+            commune ? `com_name LIKE ${quote(`${commune}%`)}` : undefined,
+            circumscription ? `libelle_de_la_circonscription LIKE ${quote(`${circumscription}%`)}` : undefined,
+            polling_station ? `code_du_b_vote = ${quote(polling_station)}` : undefined,
+          ]),
+          order_by: 'voix DESC',
+          limit,
+        });
+        return jsonResult({
+          total_rows: data.total_count,
+          results: data.results.map(mapBallotRow),
+        });
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : 'Failed to fetch legislative R2');
+      }
+    }
+  );
+
+  server.tool(
+    'reunion_get_presidential_2022_round1',
+    'Per-polling-station results of the 2022 presidential election (1st round) in La Réunion.',
+    {
+      commune: z.string().optional().describe('Commune filter (prefix match)'),
+      candidate: z.string().optional().describe('Candidate last-name filter (prefix match on nom)'),
+      polling_station: z.string().optional().describe('Polling-station code filter (exact)'),
+      limit: z.number().int().min(1).max(500).default(100),
+    },
+    async ({ commune, candidate, polling_station, limit }) => {
+      try {
+        const data = await client.getRecords<RecordObject>(DATASET_PRES_2022_T1, {
+          where: buildWhere([
+            commune ? `com_name LIKE ${quote(`${commune}%`)}` : undefined,
+            candidate ? `nom LIKE ${quote(`${candidate.toUpperCase()}%`)}` : undefined,
+            polling_station ? `code_du_b_vote = ${quote(polling_station)}` : undefined,
+          ]),
+          order_by: 'voix DESC',
+          limit,
+        });
+        return jsonResult({
+          total_rows: data.total_count,
+          results: data.results.map(mapBallotRow),
+        });
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : 'Failed to fetch presidential R1');
+      }
+    }
+  );
+
+  server.tool(
+    'reunion_search_boamp',
+    'Search BOAMP public-procurement notices for La Réunion (tenders, contract awards, market announcements).',
+    {
+      query: z.string().optional().describe('Free-text search'),
+      buyer: z.string().optional().describe('Buyer name filter (prefix match on nomacheteur)'),
+      procedure_type: z.string().optional().describe('Procedure category filter (prefix match)'),
+      limit: z.number().int().min(1).max(100).default(25),
+    },
+    async ({ query, buyer, procedure_type, limit }) => {
+      try {
+        const data = await client.getRecords<RecordObject>(DATASET_BOAMP, {
+          where: buildWhere([
+            query ? `search(${quote(query)})` : undefined,
+            buyer ? `nomacheteur LIKE ${quote(`${buyer}%`)}` : undefined,
+            procedure_type ? `procedure_categorise LIKE ${quote(`${procedure_type}%`)}` : undefined,
+          ]),
+          order_by: 'dateparution DESC',
+          limit,
+        });
+        return jsonResult({
+          total_notices: data.total_count,
+          notices: data.results.map((row) => ({
+            id: pickString(row, ['id']),
+            web_id: pickString(row, ['idweb']),
+            object: pickString(row, ['objet']),
+            buyer: pickString(row, ['nomacheteur']),
+            awardee: pickString(row, ['titulaire']),
+            family_label: pickString(row, ['famille_libelle']),
+            procedure_type: pickString(row, ['type_procedure']),
+            procedure_label: pickString(row, ['procedure_libelle']),
+            procedure_category: pickString(row, ['procedure_categorise']),
+            nature: pickString(row, ['nature_libelle']),
+            sub_nature: pickString(row, ['sousnature_libelle']),
+            published_at: pickString(row, ['dateparution']),
+            response_deadline: pickString(row, ['datelimitereponse']),
+            state: pickString(row, ['etat']),
+            url: pickString(row, ['url_avis']),
+          })),
+        });
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : 'Failed to search BOAMP');
       }
     }
   );

--- a/src/modules/environment.ts
+++ b/src/modules/environment.ts
@@ -12,6 +12,7 @@ const DATASET_RGE_COMPANIES = 'liste-des-entreprises-rge-2';
 const DATASET_ZNIEFF = 'zones-naturelles-d-interet-ecologique-faunistique-et-floristique-a-la-reunion';
 const DATASET_PNRUN = 'pnrun_2021';
 const DATASET_PETROLEUM = 'donnees-locales-de-consommation-de-produits-petroliers-a-la-reunion';
+const DATASET_WATER_POIS = 'les-points-d-activite-ou-d-interet-la-gestion-des-eaux';
 
 export function registerEnvironmentTools(server: McpServer): void {
   server.tool(
@@ -215,6 +216,39 @@ export function registerEnvironmentTools(server: McpServer): void {
         });
       } catch (error) {
         return errorResult(error instanceof Error ? error.message : 'Failed to fetch petroleum consumption');
+      }
+    }
+  );
+
+  server.tool(
+    'reunion_list_water_management_points',
+    'List points of activity / interest related to water management in La Réunion (intakes, treatment plants, etc.).',
+    {
+      nature: z.string().optional().describe('Nature filter (prefix match, e.g. "Captage")'),
+      origine: z.string().optional().describe('Origin / source filter (prefix match)'),
+      limit: z.number().int().min(1).max(200).default(50),
+    },
+    async ({ nature, origine, limit }) => {
+      try {
+        const data = await client.getRecords<RecordObject>(DATASET_WATER_POIS, {
+          where: buildWhere([
+            nature ? `nature LIKE ${quote(`${nature}%`)}` : undefined,
+            origine ? `origine LIKE ${quote(`${origine}%`)}` : undefined,
+          ]),
+          limit,
+        });
+        return jsonResult({
+          total_points: data.total_count,
+          points: data.results.map((row) => ({
+            id: pickString(row, ['id']),
+            origin: pickString(row, ['origine']),
+            nature: pickString(row, ['nature']),
+            toponym: pickString(row, ['toponyme']),
+            importance: pickString(row, ['importance']),
+          })),
+        });
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : 'Failed to list water points');
       }
     }
   );

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -24,7 +24,7 @@ import { registerTransportTools } from './transport.js';
 import { registerUrbanismTools } from './urbanism.js';
 import { registerWeatherTools } from './weather.js';
 
-export const TOOL_COUNT = 92;
+export const TOOL_COUNT = 96;
 
 /**
  * Register all tool modules with the MCP server.


### PR DESCRIPTION
## Summary
4 new tools (TOOL_COUNT 92 → 96) covering datasets we'd skipped during the issue rollout:

- **\`reunion_get_presidential_2022_round1\`** — per-polling-station results of the 2022 presidential 1st round (11 160 rows). Filters: commune, candidate last-name, polling-station code.
- **\`reunion_get_legislative_2022_round2\`** — completes the legislative pair (R1 already shipped in #26). 1 860 rows.
- **\`reunion_search_boamp\`** — BOAMP public-procurement notices for La Réunion (20 829 records). Filters: free-text, buyer, procedure category.
- **\`reunion_list_water_management_points\`** — water-management points of interest (intakes, treatment plants, 116 records). Filters: nature, origine.

The 3 election tools share schema → factored a \`mapBallotRow\` helper in \`administration.ts\`.

Why no volcano / cyclone / tides as originally proposed: the regionreunion.com catalog doesn't actually carry those datasets — only national admin / territorial / civic data. Pivoted to what's there.

## Test plan
- [x] \`npm run build\` + \`npm test\` (25)
- [x] \`npm run test:smoke\` updated with the 4 new tools (53 OK / 0 FAIL)