### PR TITLE
chore: v1.2.0 — README sync + row-mapping regression test

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,17 @@ MCP server for [La Réunion](https://data.regionreunion.com/) public open data, 
 
 ## What it covers
 
-Backed by the OpenDataSoft Explore v2.1 API at `data.regionreunion.com`. Currently **88 tools** across 20 modules. A **catalog** module lets the client reach any of the ~270 datasets that aren't wired to a dedicated tool yet.
+Backed by the OpenDataSoft Explore v2.1 API at `data.regionreunion.com`. Currently **96 tools** across 21 modules. A **catalog** module lets the client reach any of the ~270 datasets that aren't wired to a dedicated tool yet.
 
 ## Modules
 
-- **Administration** — public-admin local counters (annuaire), RNA associations registry, elected officials, 2022 legislative 1st-round results per polling station, QPV priority neighborhoods, baby names since 2000.
+- **Administration** — public-admin local counters (annuaire), RNA associations registry, elected officials, 2022 presidential & legislative results per polling station (rounds 1 & 2 for legislative), BOAMP public-procurement notices, QPV priority neighborhoods, baby names since 2000.
+- **Commune** — composite tools that join several datasets in parallel: \`reunion_find_commune\` (fuzzy resolver to canonical INSEE code), \`reunion_commune_profile\` (population + QPV + schools + businesses + accidents + museums in one call), \`reunion_compare_communes\` (side-by-side on 2-5 communes), \`reunion_iris_profile\` (IRIS metadata + 2014 income/poverty/inequality indicators).
 - **Culture** — Musées de France directory, Joconde collection search, public libraries, festivals, annual museum attendance.
 - **Economy** — SIRENE v3 establishment search, INSEE monthly CPI, FEDER 2014-2020 beneficiaries, coworking spaces, IRIS-level income/poverty indicators.
 - **Education** — middle-school & lycée IPS, Génération 2024 label, Parcoursup programs, geolocated school directory, REP/REP+ priority-education schools, higher-ed enrollment, training orgs/CFA.
 - **Employment** (`demandeurs-d-emploi-…-a-la-reunion`) — Pôle emploi jobseeker counts by age/sex and by commune.
-- **Environment** — OpenAQ air-quality, household waste tonnage, RGE eco-renovation companies, ZNIEFF protected zones, Parc national perimeters, petroleum-product consumption.
+- **Environment** — OpenAQ air-quality, household waste tonnage, RGE eco-renovation companies, ZNIEFF protected zones, Parc national perimeters, petroleum-product consumption, water-management points of interest.
 - **Facilities** (`base-permanente-des-equipements-geolocalisee-la-reunion`, `equipements-sportifs`) — INSEE BPE facilities and the national sport-equipment inventory, filtered to Réunion.
 - **Geography** (`ban-lareunion`, `bal-la-possession`, `communes-millesime-france`, `cantons-millesime-france`, `intercommunalites-millesime-france`, `iris-millesime-france`, `les-20-quartiers-villesaintdenis`) — BAN/BAL addresses and the official communes / cantons / EPCI / IRIS / Saint-Denis quarters reference layers.
 - **Health** — CNAM health-professional directory, COVID stats, pathologies, FINESS, Possession health pros.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-reunion",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "mcpName": "io.github.Hug0x0/mcp-reunion",
   "description": "MCP server for Réunion open data (data.regionreunion.com)",
   "homepage": "https://github.com/Hug0x0/mcp-reunion",

--- a/tests/tools-mapping.test.ts
+++ b/tests/tools-mapping.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { client } from '../src/client.js';
+import { registerGeographyTools } from '../src/modules/geography.js';
+
+// Regression guard: OpenDataSoft v2.1 wraps some text fields as single-element
+// arrays (com_name → ["Saint-Denis"]). The fix lives in pickValue. If anyone
+// reverts that, list_communes (and friends) silently start emitting empty
+// strings for every name field — caught by this test.
+
+interface CapturedTool {
+  schema: unknown;
+  handler: (args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>;
+}
+
+class FakeMcpServer {
+  tools = new Map<string, CapturedTool>();
+  tool(name: string, _desc: string, schema: unknown, handler: CapturedTool['handler']): void {
+    this.tools.set(name, { schema, handler });
+  }
+}
+
+describe('row-mapping unwraps ODS v2.1 single-element arrays', () => {
+  let server: FakeMcpServer;
+  let spy: ReturnType<typeof vi.spyOn<typeof client, 'getRecords'>>;
+
+  beforeEach(() => {
+    server = new FakeMcpServer();
+    registerGeographyTools(server as unknown as McpServer);
+    spy = vi.spyOn(client, 'getRecords').mockResolvedValue({
+      total_count: 1,
+      results: [
+        {
+          // Every textual field is wrapped, mirroring real ODS v2.1 behavior.
+          com_name: ['Saint-Denis'],
+          com_code: ['97411'],
+          com_current_code: ['97411'],
+          epci_code: ['200030518'],
+          epci_name: ['CINOR'],
+          ze2020_name: ['La Réunion'],
+          bv2022_name: ['Saint-Denis'],
+          dep_name: ['La Réunion'],
+          reg_name: ['La Réunion'],
+          year: ['2024'],
+        },
+      ],
+    } as never);
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  it('list_communes emits scalar strings, not arrays, for name / code / EPCI fields', async () => {
+    const tool = server.tools.get('reunion_list_communes');
+    expect(tool).toBeDefined();
+    const result = await tool!.handler({ limit: 1 });
+    const payload = JSON.parse(result.content[0].text);
+    const commune = payload.communes[0];
+    expect(commune.name).toBe('Saint-Denis');
+    expect(commune.insee_code).toBe('97411');
+    expect(commune.epci_name).toBe('CINOR');
+    expect(commune.region).toBe('La Réunion');
+    // Ensure none of the picked values leaked through as an array.
+    for (const value of Object.values(commune)) {
+      expect(Array.isArray(value)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- README count: 88 → 96 tools, 20 → 21 modules. Adds the **Commune** bullet (find / profile / compare / iris_profile composites) and updates Administration (presidential 2022, legis R2, BOAMP) and Environment (water management) bullets.
- \`package.json\` 1.1.0 → 1.2.0
- New \`tests/tools-mapping.test.ts\`: regression guard for the ODS v2.1 single-element-array unwrap (the silent bug we hit in #33). Mocks \`getRecords\` returning array-wrapped fields, runs \`list_communes\`, asserts the output contains scalar strings.

## Test plan
- [x] \`npm test\` → 26 passed (1 new)
- [x] \`npm run build\`