### PR TITLE
feat: 2024 legislative + European elections via data.gouv.fr

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ MCP server for [La Réunion](https://data.regionreunion.com/) public open data, 
 
 ## What it covers
 
-Backed by the OpenDataSoft Explore v2.1 API at `data.regionreunion.com`. Currently **96 tools** across 21 modules. A **catalog** module lets the client reach any of the ~270 datasets that aren't wired to a dedicated tool yet.
+Primary source: the OpenDataSoft Explore v2.1 API at `data.regionreunion.com`. A small **National elections** module also queries `tabular-api.data.gouv.fr` for the 2024 anticipated legislative + European results that the regional portal doesn't carry. Currently **99 tools** across 22 modules. A **catalog** module lets the client reach any of the ~270 datasets at `data.regionreunion.com` that aren't wired to a dedicated tool yet.
 
 ## Modules
 
@@ -21,6 +21,7 @@ Backed by the OpenDataSoft Explore v2.1 API at `data.regionreunion.com`. Current
 - **Geography** (`ban-lareunion`, `bal-la-possession`, `communes-millesime-france`, `cantons-millesime-france`, `intercommunalites-millesime-france`, `iris-millesime-france`, `les-20-quartiers-villesaintdenis`) — BAN/BAL addresses and the official communes / cantons / EPCI / IRIS / Saint-Denis quarters reference layers.
 - **Health** — CNAM health-professional directory, COVID stats, pathologies, FINESS, Possession health pros.
 - **Hospitality** (`etablissements-touristiques-lareunion-wssoubik`, `hebergements-classespublic`, `localisation-potentielle-ecolodge-lareunion`) — tourism establishments, classified accommodations, ecolodge zones.
+- **National elections** (`tabular-api.data.gouv.fr` — Ministère de l'Intérieur) — 2024 anticipated legislative results (rounds 1 & 2) per Réunion circonscription, and 2024 European results aggregated for département 974. Complements the 2022 results carried by the regional portal.
 - **Housing** (`logements-et-logements-sociaux-…`, `couts-et-surfaces-moyens-…`) — departmental housing atlas and social-housing costs.
 - **Possession** (`donnees-essentielles-marches-publics-…`, `subventions-attribuees-…`) — La Possession public procurement contracts and association grants.
 - **Social** — CAF beneficiaries and prestation amounts, childcare facilities (Saint-Denis + Possession).

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -80,6 +80,13 @@ const TESTS = [
   { pr: 35, tool: 'list_water_management_points', dataset: 'les-points-d-activite-ou-d-interet-la-gestion-des-eaux', params: { limit: 1 } },
 ];
 
+// data.gouv.fr tabular-api smoke targets — separate base URL, separate run.
+const DATA_GOUV_TESTS = [
+  { tool: 'legislative_2024_round1', resource: '5163f2e3-1362-4c35-89a0-1934bb74f2d9' },
+  { tool: 'legislative_2024_round2', resource: '41ed46cd-77c2-4ecc-b8eb-374aa953ca39' },
+  { tool: 'european_2024_by_dept',   resource: 'b77cc4da-644f-4323-b6f7-ae6fe9b33f86' },
+];
+
 function buildUrl(dataset, params) {
   const qs = new URLSearchParams();
   for (const [k, v] of Object.entries(params)) {
@@ -122,6 +129,26 @@ async function run() {
       console.log(pad('#' + r.pr, 5) + pad(r.status, 7) + pad('-', 10) + pad('-', 5) + r.tool + '  —  [' + (r.http || '?') + '] ' + errSnippet);
     }
   }
+  // data.gouv.fr tabular-api smoke
+  for (const t of DATA_GOUV_TESTS) {
+    const u = `https://tabular-api.data.gouv.fr/api/resources/${t.resource}/data/?${encodeURIComponent('Code département')}__exact=974&page_size=1`;
+    try {
+      const res = await fetch(u);
+      const body = await res.json();
+      if (!res.ok) {
+        fail++;
+        console.log(pad('dgF', 5) + pad('FAIL', 7) + pad('-', 10) + pad('-', 5) + t.tool + '  —  [' + res.status + ']');
+        continue;
+      }
+      const got = body.data?.length ?? 0;
+      ok++;
+      console.log(pad('dgF', 5) + pad('OK', 7) + pad('-', 10) + pad(got, 5) + t.tool);
+    } catch (err) {
+      fail++;
+      console.log(pad('dgF', 5) + pad('FAIL', 7) + pad('-', 10) + pad('-', 5) + t.tool + '  —  ' + err.message);
+    }
+  }
+
   console.log('-'.repeat(100));
   console.log(`Totals: ${ok} OK, ${fail} FAIL`);
   process.exitCode = fail === 0 ? 0 : 1;

--- a/src/clients/data-gouv.ts
+++ b/src/clients/data-gouv.ts
@@ -1,0 +1,67 @@
+// src/clients/data-gouv.ts
+//
+// Thin client for tabular-api.data.gouv.fr — lets us query the Ministry of
+// Interior's France-wide CSVs (post-2022 election results that the regional
+// data.regionreunion.com portal doesn't carry) filtered server-side.
+//
+// Query syntax: `?<Column>__<op>=<value>` where op ∈ {exact, contains, gt, ...}.
+// Column names containing spaces/accents must be URL-encoded.
+
+const BASE = 'https://tabular-api.data.gouv.fr/api';
+
+export interface TabularResponse<T = Record<string, unknown>> {
+  data: T[];
+  links?: { profile?: string; next?: string };
+  meta?: { total?: number; page_size?: number };
+}
+
+export interface TabularQuery {
+  /** Equality / contains filters keyed by exact column name (with spaces / accents). */
+  filters?: Record<string, string | number | undefined>;
+  /** Page size (data.gouv default is 20, max 50). */
+  pageSize?: number;
+  /** Pagination page (1-indexed). */
+  page?: number;
+}
+
+export class DataGouvTabularClient {
+  private readonly timeout = 30000;
+
+  async query<T = Record<string, unknown>>(
+    resourceId: string,
+    options: TabularQuery = {}
+  ): Promise<TabularResponse<T>> {
+    const url = new URL(`${BASE}/resources/${resourceId}/data/`);
+
+    if (options.filters) {
+      for (const [column, value] of Object.entries(options.filters)) {
+        if (value === undefined || value === null || value === '') continue;
+        // tabular-api expects `<column>__exact=<value>`
+        url.searchParams.set(`${column}__exact`, String(value));
+      }
+    }
+    if (options.pageSize) url.searchParams.set('page_size', String(options.pageSize));
+    if (options.page) url.searchParams.set('page', String(options.page));
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+    try {
+      const response = await fetch(url.toString(), {
+        headers: {
+          Accept: 'application/json',
+          'User-Agent': 'mcp-reunion/1.2',
+        },
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`tabular-api ${response.status}: ${body.slice(0, 300)}`);
+      }
+      return (await response.json()) as TabularResponse<T>;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+export const dataGouvClient = new DataGouvTabularClient();

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -15,6 +15,7 @@ import { registerGeographyTools } from './geography.js';
 import { registerHealthTools } from './health.js';
 import { registerHospitalityTools } from './hospitality.js';
 import { registerHousingTools } from './housing.js';
+import { registerNationalElectionsTools } from './national-elections.js';
 import { registerPossessionTools } from './possession.js';
 import { registerSocialTools } from './social.js';
 import { registerTelecomTools } from './telecom.js';
@@ -24,7 +25,7 @@ import { registerTransportTools } from './transport.js';
 import { registerUrbanismTools } from './urbanism.js';
 import { registerWeatherTools } from './weather.js';
 
-export const TOOL_COUNT = 96;
+export const TOOL_COUNT = 99;
 
 /**
  * Register all tool modules with the MCP server.
@@ -43,6 +44,7 @@ export function registerAllTools(server: McpServer): void {
   registerHealthTools(server);
   registerHospitalityTools(server);
   registerHousingTools(server);
+  registerNationalElectionsTools(server);
   registerPossessionTools(server);
   registerSocialTools(server);
   registerTelecomTools(server);

--- a/src/modules/national-elections.ts
+++ b/src/modules/national-elections.ts
@@ -1,0 +1,190 @@
+// src/modules/national-elections.ts
+//
+// Post-2022 election results that the regional data.regionreunion.com portal
+// doesn't carry. Sourced from the Ministry of Interior's France-wide CSVs on
+// data.gouv.fr (queried via tabular-api.data.gouv.fr) and filtered server-side
+// to département 974.
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { dataGouvClient } from '../clients/data-gouv.js';
+import { errorResult, jsonResult } from '../utils/helpers.js';
+
+const RES_LEGIS_2024_T1 = '5163f2e3-1362-4c35-89a0-1934bb74f2d9';
+const RES_LEGIS_2024_T2 = '41ed46cd-77c2-4ecc-b8eb-374aa953ca39';
+const RES_EUROP_2024_DEPT = 'b77cc4da-644f-4323-b6f7-ae6fe9b33f86';
+
+type Row = Record<string, unknown>;
+
+function num(v: unknown): number | undefined {
+  if (typeof v === 'number') return Number.isFinite(v) ? v : undefined;
+  if (typeof v === 'string' && v.trim()) {
+    const n = Number(v.replace(',', '.').replace('%', ''));
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return undefined;
+}
+
+function str(v: unknown): string | undefined {
+  if (typeof v === 'string') return v.trim() || undefined;
+  if (typeof v === 'number') return String(v);
+  return undefined;
+}
+
+// Melt the wide candidate columns (Nom candidat 1..19, Voix 1..19, etc.) into
+// a clean array — skip empty slots so we only return real candidates.
+function meltCandidates(row: Row, maxN = 19) {
+  const out = [];
+  for (let i = 1; i <= maxN; i++) {
+    const last = str(row[`Nom candidat ${i}`]);
+    if (!last) continue;
+    out.push({
+      panel: num(row[`Numéro de panneau ${i}`]),
+      nuance: str(row[`Nuance candidat ${i}`]),
+      last_name: last,
+      first_name: str(row[`Prénom candidat ${i}`]),
+      sex: str(row[`Sexe candidat ${i}`]),
+      votes: num(row[`Voix ${i}`]),
+      pct_registered: str(row[`% Voix/inscrits ${i}`]),
+      pct_expressed: str(row[`% Voix/exprimés ${i}`]),
+      elected: str(row[`Elu ${i}`]),
+    });
+  }
+  return out.sort((a, b) => (b.votes ?? 0) - (a.votes ?? 0));
+}
+
+function meltLists(row: Row, maxN = 38) {
+  const out = [];
+  for (let i = 1; i <= maxN; i++) {
+    const name = str(row[`Libellé de liste ${i}`]);
+    if (!name) continue;
+    out.push({
+      panel: num(row[`Numéro de panneau ${i}`]),
+      nuance: str(row[`Nuance liste ${i}`]),
+      list_name: name,
+      list_short: str(row[`Libellé abrégé de liste ${i}`]),
+      votes: num(row[`Voix ${i}`]),
+      pct_registered: str(row[`% Voix/inscrits ${i}`]),
+      pct_expressed: str(row[`% Voix/exprimés ${i}`]),
+      seats: num(row[`Sièges ${i}`]),
+    });
+  }
+  return out.sort((a, b) => (b.votes ?? 0) - (a.votes ?? 0));
+}
+
+function mapBaseStats(row: Row) {
+  return {
+    registered: num(row.Inscrits),
+    voters: num(row.Votants),
+    pct_voters: str(row['% Votants']),
+    abstentions: num(row.Abstentions),
+    pct_abstentions: str(row['% Abstentions']),
+    expressed: num(row.Exprimés),
+    blank: num(row.Blancs),
+    null_votes: num(row.Nuls),
+  };
+}
+
+async function fetchLegislative2024(resourceId: string, circumscription?: number) {
+  const filters: Record<string, string | number | undefined> = {
+    'Code département': '974',
+  };
+  if (circumscription !== undefined) {
+    // The CSV stores the full code (974 + 0N), e.g. circo 1 → "97401".
+    filters['Code circonscription législative'] = `9740${circumscription}`;
+  }
+  return dataGouvClient.query<Row>(resourceId, { filters, pageSize: 50 });
+}
+
+export function registerNationalElectionsTools(server: McpServer): void {
+  server.tool(
+    'reunion_get_legislative_2024_round1',
+    'Per-circonscription results of the 2024 anticipated legislative elections (1st round, 30 June 2024) in La Réunion. Source: Ministry of Interior via data.gouv.fr.',
+    {
+      circumscription: z
+        .number()
+        .int()
+        .min(1)
+        .max(7)
+        .optional()
+        .describe('Réunion circonscription number (1-7), omit for all'),
+    },
+    async ({ circumscription }) => {
+      try {
+        const data = await fetchLegislative2024(RES_LEGIS_2024_T1, circumscription);
+        return jsonResult({
+          source: 'data.gouv.fr (Ministère de l\'Intérieur)',
+          round: 1,
+          rows: data.data.map((row) => ({
+            department: str(row['Libellé département']),
+            circumscription_code: str(row['Code circonscription législative']),
+            circumscription_name: str(row['Libellé circonscription législative']),
+            ...mapBaseStats(row),
+            candidates: meltCandidates(row),
+          })),
+        });
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : 'Failed to fetch legislative 2024 R1');
+      }
+    }
+  );
+
+  server.tool(
+    'reunion_get_legislative_2024_round2',
+    'Per-circonscription results of the 2024 anticipated legislative elections (2nd round, 7 July 2024) in La Réunion. Source: Ministry of Interior via data.gouv.fr.',
+    {
+      circumscription: z
+        .number()
+        .int()
+        .min(1)
+        .max(7)
+        .optional()
+        .describe('Réunion circonscription number (1-7), omit for all'),
+    },
+    async ({ circumscription }) => {
+      try {
+        const data = await fetchLegislative2024(RES_LEGIS_2024_T2, circumscription);
+        return jsonResult({
+          source: 'data.gouv.fr (Ministère de l\'Intérieur)',
+          round: 2,
+          rows: data.data.map((row) => ({
+            department: str(row['Libellé département']),
+            circumscription_code: str(row['Code circonscription législative']),
+            circumscription_name: str(row['Libellé circonscription législative']),
+            ...mapBaseStats(row),
+            candidates: meltCandidates(row),
+          })),
+        });
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : 'Failed to fetch legislative 2024 R2');
+      }
+    }
+  );
+
+  server.tool(
+    'reunion_get_european_2024',
+    'Results of the 9 June 2024 European elections aggregated for département 974 (La Réunion). Returns the final standings of all 38 lists. Source: Ministry of Interior via data.gouv.fr.',
+    {},
+    async () => {
+      try {
+        const data = await dataGouvClient.query<Row>(RES_EUROP_2024_DEPT, {
+          filters: { 'Code département': '974' },
+          pageSize: 5,
+        });
+        const row = data.data[0];
+        if (!row) {
+          return errorResult('No data returned for département 974 in European 2024 dataset');
+        }
+        return jsonResult({
+          source: 'data.gouv.fr (Ministère de l\'Intérieur)',
+          election: 'européennes 2024',
+          department: str(row['Libellé département']),
+          ...mapBaseStats(row),
+          lists: meltLists(row),
+        });
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : 'Failed to fetch European 2024');
+      }
+    }
+  );
+}

--- a/tests/data-gouv-client.test.ts
+++ b/tests/data-gouv-client.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DataGouvTabularClient } from '../src/clients/data-gouv.js';
+
+describe('DataGouvTabularClient', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let client: DataGouvTabularClient;
+
+  beforeEach(() => {
+    client = new DataGouvTabularClient();
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200, headers: { 'content-type': 'application/json' } })
+    );
+  });
+  afterEach(() => { fetchSpy.mockRestore(); });
+
+  it('builds the URL with `<column>__exact=<value>` for each filter and URL-encodes accents/spaces', async () => {
+    await client.query('abc-123', { filters: { 'Code département': '974' } });
+    const url = (fetchSpy.mock.calls[0][0] as string).toString();
+    expect(url).toContain('https://tabular-api.data.gouv.fr/api/resources/abc-123/data/');
+    expect(url).toContain('Code+d%C3%A9partement__exact=974');
+  });
+
+  it('skips undefined / empty filters', async () => {
+    await client.query('abc-123', {
+      filters: { 'Code département': '974', 'Code circo': undefined, x: '' },
+    });
+    const url = (fetchSpy.mock.calls[0][0] as string).toString();
+    expect(url).toContain('Code+d%C3%A9partement__exact=974');
+    expect(url).not.toContain('Code+circo');
+    expect(url).not.toContain('x__exact');
+  });
+
+  it('passes pageSize / page through', async () => {
+    await client.query('abc-123', { pageSize: 50, page: 2 });
+    const url = (fetchSpy.mock.calls[0][0] as string).toString();
+    expect(url).toContain('page_size=50');
+    expect(url).toContain('page=2');
+  });
+
+  it('throws with the response body when the API returns non-2xx', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response('boom', { status: 500 })
+    );
+    await expect(client.query('abc-123')).rejects.toThrow(/tabular-api 500/);
+  });
+});


### PR DESCRIPTION
## Summary
The regional \`data.regionreunion.com\` portal stops at 2022. To get more recent election results, this PR adds a **second data source** — the Ministry of Interior's France-wide CSVs published on data.gouv.fr — queried via \`tabular-api.data.gouv.fr\` and filtered server-side to département 974.

3 new tools (TOOL_COUNT 96 → 99):

- \`reunion_get_legislative_2024_round1\` — anticipated legislative 30 June 2024, per Réunion circonscription (filterable, 1-7)
- \`reunion_get_legislative_2024_round2\` — anticipated legislative 7 July 2024, per Réunion circonscription
- \`reunion_get_european_2024\` — European elections 9 June 2024 aggregated for département 974, returns the standings of all 38 lists

### Implementation
- New \`src/clients/data-gouv.ts\` — minimal \`DataGouvTabularClient\` with the \`<column>__exact=<value>\` filter syntax of tabular-api
- New \`src/modules/national-elections.ts\` — wide-format CSVs (19 candidate slots / 38 list slots) melted into clean arrays, sorted by votes desc
- Smoke test extended with 3 \`data.gouv.fr\` targets (53 ODS + 3 dgF = 56 OK)
- 4 unit tests on \`DataGouvTabularClient\` (URL building, filter encoding, error handling)

### Live sanity
- R2 winners on the 7 Réunion circos: NAILLET (UG, c1), LEBON (UG, c2), RIVIERE (RN, c3), KBIDI (DVG, c4), RATENON (DVG, c5), MAILLOT (DVG, c6), GAILLARD (UG, c7)
- Européennes 974: 26.37% turnout, top list "La France revient" 31.71%

## Test plan
- [x] \`npm run build\`, \`npm test\` (30 passed, +4 new)
- [x] \`npm run test:smoke\` (56 OK / 0 FAIL)